### PR TITLE
Update to 0.48.9 fixing deps and paths

### DIFF
--- a/cursor.spec
+++ b/cursor.spec
@@ -1,14 +1,15 @@
 Name:           cursor
-Version:        0.45.14
+Version:        0.48.9
 Release:        1%{?dist}
 Summary:        Cursor - The AI Code Editor
 
 License:        LicenseRef-Proprietary  # Update according to the actual license
 URL:            https://www.cursor.com/
-Source0:        cursor-0.45.14x86_64.AppImage
+Source0:        Cursor-0.48.9-x86_64.AppImage
 
 BuildArch:      x86_64
 ExclusiveArch:  x86_64
+Requires:       ffmpeg
 
 %description
 Built to make you extraordinarily productive, Cursor is the best way to code with AI.
@@ -27,7 +28,7 @@ mkdir -p %{buildroot}/usr/local/cursor/
 cp -r squashfs-root/* %{buildroot}/usr/local/cursor/
 
 mkdir -p %{buildroot}/lib64
-cp squashfs-root/libffmpeg.so %{buildroot}/lib64/libffmpeg.so
+cp squashfs-root/usr/share/cursor/libffmpeg.so %{buildroot}/lib64/libffmpeg.so
 
 mkdir -p %{buildroot}/usr/share/icons/hicolor/
 cp -r squashfs-root/usr/share/icons/hicolor/* %{buildroot}/usr/share/icons/hicolor/
@@ -38,7 +39,7 @@ mkdir -p %{buildroot}/usr/share/applications/
 cp squashfs-root/cursor.desktop %{buildroot}/usr/share/applications/
 
 mkdir -p %{buildroot}/usr/local/bin/
-ln -s ../cursor/cursor %{buildroot}/usr/local/bin/cursor
+ln -s ../cursor/AppRun %{buildroot}/usr/local/bin/cursor
 
 %post
 gtk-update-icon-cache /usr/share/icons/hicolor
@@ -50,3 +51,7 @@ chmod -R 755 /usr/local/cursor/resources
 /usr/local/bin/cursor
 /usr/share/applications/cursor.desktop
 /usr/share/icons/hicolor/*/apps/cursor.png
+
+%changelog
+* Fri Apr 18 2025 Your Name <andrea.manenti@proton.me> - 0.48.9-1
+- Updated paths and added ffmpeg dependency


### PR DESCRIPTION
## Changelog

 - Changed the version and the name of the file slightly
 - Changed the executable name which now is `AppRun`
 - Updated dependencies: added `ffmpeg`